### PR TITLE
Add a range slider for stream counts

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -197,24 +197,17 @@ app.layout = dbc.Container([
                 clearable=False
             ),
 
-            html.Span("Group by:"),
-
-            dcc.Dropdown(
-                id="timespan-dropdown",
-                options=timespan_options,
-                value=timespan_options[0]["value"],
-                clearable=False
-            ),
-
             dbc.RadioItems(
-                # TODO: Make this radio button nicer, for instance with a slider
                 id="filter-column",
                 options=[
                     {"label": "Artist", "value": "master_metadata_album_artist_name"},
                     {"label": "Song Title", "value": "master_metadata_track_name"}
                 ],
-                value="master_metadata_album_artist_name"
+                value="master_metadata_album_artist_name",
+                inline=True
             ),
+
+            # TODO: Add a double slider to filter by the amount of streams
 
             dbc.Input(
                 id="filter-value",
@@ -228,6 +221,15 @@ app.layout = dbc.Container([
                 config = {
                     "displayModeBar": False
                 }
+            ),
+
+            html.Span("Group by:"),
+
+            dcc.Dropdown(
+                id="timespan-dropdown",
+                options=timespan_options,
+                value=timespan_options[0]["value"],
+                clearable=False
             )
         ], width=2),
 
@@ -385,22 +387,6 @@ def show_random_forest(data, predictions):
 
     fig.update_layout(clickmode='event+select')
 
-    # app.logger.info(selected_points)
-
-    # # Filter out the unselected points
-    # fig.update_traces(
-    #     selectedpoints=[selected_points.index],
-    #     unselected={
-    #         "marker": {"opacity": 0.1},
-    #         # TODO: Remove the hover from unselected points
-    #     },
-    #     selected={
-    #         "marker": {"color": "red"},
-    #     }
-    # )
-
-    # app.logger.info(fig)
-
     return fig
 
 
@@ -416,15 +402,15 @@ def display_top_tracks(data):
 
     layout = []
     for index, track in top_tracks.iterrows():
-        # album_cover = sp.track(track["spotify_track_uri"][14:])["album"]["images"][-1]["url"]
+        album_cover = sp.track(track["spotify_track_uri"][14:])["album"]["images"][-1]["url"]
         song_tile = dbc.Row([
             dbc.Col([
                 html.H3("#{}".format(index+1))
             ], width=1, class_name="p-0"),
 
-            # dbc.Col([
-            #     html.Img(src=album_cover)
-            # ], width=2),
+            dbc.Col([
+                html.Img(src=album_cover)
+            ], width=2),
 
             dbc.Col([
                 html.H5(track["master_metadata_track_name"]),
@@ -467,29 +453,29 @@ def display_lime_plot(model, predictions, selection):
     return dcc.Graph(figure=fig)
 
 
-# @app.callback(
-#     Output("predicted-tracks", "children"),
-#     Input("full-dataset", "data"),
-#     Input("model", "data")
-# )
-# def predict_new_tracks(data, model):
+@app.callback(
+    Output("predicted-tracks", "children"),
+    Input("full-dataset", "data"),
+    Input("model", "data")
+)
+def predict_new_tracks(data, model):
     
-#     df = pd.read_json(data)
-#     rfc = jsonpickle.decode(model)
+    df = pd.read_json(data)
+    rfc = jsonpickle.decode(model)
 
-#     AMOUNT_OF_PREDICTIONS = 10
+    AMOUNT_OF_PREDICTIONS = 10
 
-#     predicted_tracks, predicted_artists = new_top_songs(df, rfc, AMOUNT_OF_PREDICTIONS)
+    predicted_tracks, predicted_artists = new_top_songs(df, rfc, AMOUNT_OF_PREDICTIONS)
 
-#     predicted_songs_list = []
+    predicted_songs_list = []
 
-#     # TODO: Make a nice layout to show the predicted top songs
-#     for i in range(AMOUNT_OF_PREDICTIONS):
-#         predicted_songs_list.append(
-#             html.Li(f"{predicted_tracks[i]} - {predicted_artists[i]}")
-#         )
+    # TODO: Make a nice layout to show the predicted top songs
+    for i in range(AMOUNT_OF_PREDICTIONS):
+        predicted_songs_list.append(
+            html.Li(f"{predicted_tracks[i]} - {predicted_artists[i]}")
+        )
 
-#     return html.Ul(children=predicted_songs_list)
+    return html.Ul(children=predicted_songs_list)
 
 
 @app.callback(

--- a/src/app.py
+++ b/src/app.py
@@ -335,6 +335,18 @@ def load_and_filter_data(path, selection, timespan, filter_column, filter):
 
 
 @app.callback(
+    Output("streams-slider", "max"),
+    Output("streams-slider", "value"),
+    Input("full-dataset", "data")
+)
+def get_highest_stream_count(data):
+    df = pd.read_json(data)
+    streams = get_top_songs(df)
+    max_count = streams.head(1)["count"][0]
+    return max_count, [0, max_count]
+
+
+@app.callback(
     Output("model", "data"),
     Output("predictions", "data"),
     Input("full-dataset", "data"),

--- a/src/app.py
+++ b/src/app.py
@@ -207,13 +207,25 @@ app.layout = dbc.Container([
                 inline=True
             ),
 
-            # TODO: Add a double slider to filter by the amount of streams
-
             dbc.Input(
                 id="filter-value",
                 type="text",
                 placeholder="Filter",
                 debounce=True # Only execute callback on enter or losing focus
+            ),
+
+            html.Span("Amount of streams:"),
+
+            # TODO: Change padding on the sides of the slider from 25px to 5px
+            dcc.RangeSlider(
+                id="streams-slider",
+                min=0, 
+                max=30, # TODO: Set the maximum value based on the actual data
+                step=1,
+                marks=None,
+                value=[0, 30], # The initial values of the handles
+                tooltip={"placement": "bottom", "always_visible": True},
+                allowCross=False # Make the handles not able to cross
             ),
 
             dcc.Graph(


### PR DESCRIPTION
The added range slider filters the points in the random forest graph. The amount of counts is updated on the slider based on the tracks in the filtered data, i.e. that match the filter set by the user, and are in the given time period